### PR TITLE
Create MANIFEST.in, fixes #1 - and fix bad import while I'm at it

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft aiohttp_rest_api/swagger_ui

--- a/aiohttp_rest_api/loader.py
+++ b/aiohttp_rest_api/loader.py
@@ -4,7 +4,7 @@ from inspect import getmembers, isclass
 
 from aiohttp.web import Application
 
-from aiohttp_rest_api.rest_endpoint  import AioHTTPRestEndpoint, SUPPORTED_METHODS
+from aiohttp_rest_api  import AioHTTPRestEndpoint, SUPPORTED_METHODS
 from aiohttp_rest_api.swagger import generate_doc_template, build_doc_from_func_doc
 
 


### PR DESCRIPTION
The problem in #1 was the fact that `include_package_data` requires some list of files to include - it can be either a `package_data` property of setup, or (preferred) a MANIFEST.in file

The second problem was an error made during changes in 53485b4b841b9c779a4c0993c341af23e6a6a9fb - `rest_endpoint.py` was renamed to `__init__.py` and should now be imported from by using just `from aiohttp_rest_api  import <stuff>` and not ` from aiohttp_rest_api.rest_endpoint  import <stuff>`

Also tested that this version doesn't throw errors by publishing it as [`aiohttp-rest-api-fork`](https://pypi.org/project/aiohttp-rest-api-fork/). I'll delete it once this is merged :)